### PR TITLE
Multiple issues fixed (#22 and #24)

### DIFF
--- a/lib/vagrant-windows-domain/config.rb
+++ b/lib/vagrant-windows-domain/config.rb
@@ -40,6 +40,16 @@ module VagrantPlugins
       # The default value is the default OU for machine objects in the domain.
       attr_accessor :ou_path
 
+      # IP address of primary DNS server
+      #
+      # Specifies the IP address you want assigned as the primary DNS server for the primary nic
+      attr_accessor :primary_dns
+
+      #IP address of the secondary DNS server
+      #
+      # Specifies the IP address you want assigned as the secondary DNS server for the primary nic
+      attr_accessor :secondary_dns
+
       # Performs an unsecure join to the specified domain.
       #
       # When this option is used username/password are not required
@@ -56,6 +66,8 @@ module VagrantPlugins
         @password          = UNSET_VALUE
         @join_options      = {}
         @ou_path           = UNSET_VALUE
+        @primary_dns       = UNSET_VALUE
+        @secondary_dns     = UNSET_VALUE
         @unsecure          = UNSET_VALUE
         @rename            = UNSET_VALUE
         @logger            = Log4r::Logger.new("vagrant::vagrant_windows_domain")
@@ -75,6 +87,8 @@ module VagrantPlugins
         @password          = nil if @password == UNSET_VALUE || @password == ""
         @join_options      = [] if @join_options == UNSET_VALUE
         @ou_path           = nil if @ou_path == UNSET_VALUE
+        @primary_dns       = nil if @primary_dns == UNSET_VALUE
+        @secondary_dns     = nil if @secondary_dns == UNSET_VALUE
         @unsecure          = false if @unsecure == UNSET_VALUE
         @rename            = true if @rename == UNSET_VALUE
       end

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -215,6 +215,8 @@ module VagrantPlugins
             domain: @config.domain,
             computer_name: @config.computer_name,
             ou_path: @config.ou_path,
+            primary_dns: @config.primary_dns,
+            secondary_dns: @config.secondary_dns,
             add_to_domain: add_to_domain,
             unsecure: @config.unsecure,
             rename: @config.rename,
@@ -244,10 +246,6 @@ module VagrantPlugins
             params["-Unsecure"] = nil
           else
             params["-Credential $credentials"] = nil
-          end
-
-          if @config.computer_name != nil && @config.computer_name != @old_computer_name
-            params["-NewName"] = "'#{@config.computer_name}'"
           end
 
           if @config.ou_path

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -30,8 +30,38 @@ $credentials = New-Object System.Management.Automation.PSCredential ($username, 
 if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	throw "$computerName already part of domain $domain"
 } else {
+	#If a value is provided for the Primary_DNS variable in the vagrantfile, powershell will attempt to determine if the string is a valid IP and will statically set the primary dns server of the vm's nic if it is.
+	<% if options[:Primary_DNS] != nil %>
+		$prim = '<%= options[:Primary_DNS] %>'
+		If ($prim -match "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+		{
+			$wmi = Get-WmiObject -ComputerName $server -Namespace "root\CIMV2" -Class "Win32_NetworkAdapterconfiguration" -Filter 'IPENABLED=TRUE' -Impersonation Impersonate -ErrorAction Stop | Where-Object { $_.DefaultIPGateway }
+			$currdns = $wmi.DNSServerSearchOrder
+			$wmi.SetDNSServerSearchOrder(@($prim, $currdns[1]))
+		}
+		else
+		{
+			throw "Invalid IP address provided"
+		}
+	<% end %>
+
+	#If a value is provided for the Secondary_DNS variable in the vagrantfile, powershell will attempt to determine if the string is a valid IP and will statically set the secondary dns server of the vm's nic if it is.
+	<% if options[:Secondary_DNS] != nil %>
+		$sec = '<%= options[:Secondary_DNS] %>'
+		If ($sec -match "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+		{
+			$wmi = Get-WmiObject -ComputerName $server -Namespace "root\CIMV2" -Class "Win32_NetworkAdapterconfiguration" -Filter 'IPENABLED=TRUE' -Impersonation Impersonate -ErrorAction Stop | Where-Object { $_.DefaultIPGateway }
+			$currdns = $wmi.DNSServerSearchOrder
+			$wmi.SetDNSServerSearchOrder(@($currdns[0], $sec))
+		}
+		else
+		{
+			throw "Invalid IP address provided"
+		}
+	<% end %>
+
 	Add-Computer <%= options[:parameters] %> -Verbose -Force -PassThru
-	
+
 	# Rename computer separately: Fixes GH issue #11
 	<% if options[:rename] === true %>
 	$completed = $false
@@ -59,7 +89,7 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	&shutdown /a
 
 	# Force shutdown the machine now
-	&shutdown /s /t 15 /c "Vagrant Halt" /f /d p:4:1	
+	&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1	
 }
 <% else %>
 if (!(Test-JoinedToADomain)) {
@@ -68,11 +98,12 @@ if (!(Test-JoinedToADomain)) {
 	Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
 	Repair-OpenSSHPasswd
 
+	#removed the shutdown of the vm when disjoining it from the domain since, as the vm is about to be destroyed anyway, so there is no use for it.
 	# Fix vagrant-windows GH-129, if there's an existing scheduled
 	# reboot cancel it so shutdown succeeds
-	&shutdown /a
+	#&shutdown /a
 
 	# Force shutdown the machine now
-	&shutdown /r /t 15 /c "Vagrant Halt" /f /d p:4:1
+	#&shutdown /r /t 15 /c "Vagrant Halt" /f /d p:4:1
 }
 <% end %>

--- a/lib/vagrant-windows-domain/version.rb
+++ b/lib/vagrant-windows-domain/version.rb
@@ -1,5 +1,5 @@
 module Vagrant
   module WindowsDomain
-    VERSION = "1.3.1"
+    VERSION = "1.3.2"
   end
 end

--- a/spec/provisioner/config_spec.rb
+++ b/spec/provisioner/config_spec.rb
@@ -37,6 +37,8 @@ describe VagrantPlugins::WindowsDomain::Config do
     its("username")          { should be_nil }
     its("password")          { should be_nil }
     its("join_options")      { should eq({})   }
+	its("primary_dns")		 { should be_nil }
+	its("secondary_dns")	 { should be_nil }
     its("ou_path")           { should be_nil }
     its("unsecure")          { should eq(false) }
 
@@ -45,6 +47,8 @@ describe VagrantPlugins::WindowsDomain::Config do
       subject.username = ""
       subject.password = ""
       subject.computer_name = ""
+      subject.primary_dns = ""
+      subject.secondary_dns = ""
       
       subject.finalize!
 
@@ -52,6 +56,9 @@ describe VagrantPlugins::WindowsDomain::Config do
       expect(subject.computer_name).to be_nil
       expect(subject.username).to be_nil
       expect(subject.password).to be_nil
+	  expect(subject.primary_dns).to be_nil
+	  expect(subject.secondary_dns).to be_nil
+	  
     end
   end
 

--- a/vagrant-windows-domain.gemspec
+++ b/vagrant-windows-domain.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-expectations", '~> 3.4.0', '>= 3.4.0'
   spec.add_development_dependency "rspec-mocks", '~> 3.4.1', '>= 3.4.1'
   spec.add_development_dependency "rspec-its", "~> 1.2.0", '>= 1.2.0'
+  spec.add_development_dependency "vagrant-spec", "~> 0.0.1", '>= 0.0.1'
 end


### PR DESCRIPTION
The modifications fix multiple issues.  The inclusion of the two new optional variables (primary_dns  and secondary_dns) allow users to optionally supply the ip addresses for the primary and secondary dns servers to statically assign to the main nic of the vm.  This will allow the computer to join the domin in question even if the vm is on a seperate subnet from the domain (the default network adapter that is used in virtual box is nat).  Further, I also fixed the error that appears when attempting to change the name of the computer when joining it to the domain.  The process which renames the computer is actually done in 2 places if the computer_name variable is assigned a value: it is added to the list of arguments that are used to run the "add-computer" command and using the actual rename-computer function as well.  I chose to remove the section which added the "-newname" parameter in the "generate_command_arguments" function.  Now, it works like a charm