### PR TITLE
Several issues fixed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   fast_finish: true
 env:
   matrix:
-  - VAGRANT_VERSION=v1.8.0
+  - VAGRANT_VERSION=v2.1.5
   global:
     secure: bs4ezY+1Wksy8hH3nymPJ3AL99mpXULVc/AIh16JetEYw1850QkX7r4gQukMlcyByKUhxucjDLid0Y+KDH5kGMM16QjrVQGhAnUQzMoLD2qPbAaxDCUqpCJtFEEQKYxJvFvEK8a5SQzAsTVG4sgABQ/MllsIIH0FjkWgFtH6050=
 script: bundle exec rake test:unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 before_install:
 - gem install bundler
 rvm:
-- 2.2.3
-- 2.3.0
+- 2.5.1
+- 2.4.4
 - ruby-head
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 before_install:
-- gem install bundler
+- gem install bundler --version 1.12.5
 rvm:
 - 2.2.3
 - 2.3.0
@@ -14,4 +14,4 @@ env:
   - VAGRANT_VERSION=v1.8.0
   global:
     secure: bs4ezY+1Wksy8hH3nymPJ3AL99mpXULVc/AIh16JetEYw1850QkX7r4gQukMlcyByKUhxucjDLid0Y+KDH5kGMM16QjrVQGhAnUQzMoLD2qPbAaxDCUqpCJtFEEQKYxJvFvEK8a5SQzAsTVG4sgABQ/MllsIIH0FjkWgFtH6050=
-script: bundle exec rake test:unit
+script: bundle _1.12.5_ exec rake test:unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: ruby
 before_install:
 - rvm @global do gem uninstall bundler --all --executables
 - gem uninstall bundler --all --executables
-- gem install bundler --version 1.12.5
-- gem install bundler --version 1.12.5
+- gem install bundler
 rvm:
 - 2.2.3
 - 2.3.0
@@ -17,4 +16,4 @@ env:
   - VAGRANT_VERSION=v1.8.0
   global:
     secure: bs4ezY+1Wksy8hH3nymPJ3AL99mpXULVc/AIh16JetEYw1850QkX7r4gQukMlcyByKUhxucjDLid0Y+KDH5kGMM16QjrVQGhAnUQzMoLD2qPbAaxDCUqpCJtFEEQKYxJvFvEK8a5SQzAsTVG4sgABQ/MllsIIH0FjkWgFtH6050=
-script: bundle _1.12.5_ exec rake test:unit
+script: bundle exec rake test:unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 before_install:
-- gem install bundler --version 1.12.5
+- gem install bundler
 rvm:
 - 2.2.3
 - 2.3.0
@@ -14,4 +14,4 @@ env:
   - VAGRANT_VERSION=v1.8.0
   global:
     secure: bs4ezY+1Wksy8hH3nymPJ3AL99mpXULVc/AIh16JetEYw1850QkX7r4gQukMlcyByKUhxucjDLid0Y+KDH5kGMM16QjrVQGhAnUQzMoLD2qPbAaxDCUqpCJtFEEQKYxJvFvEK8a5SQzAsTVG4sgABQ/MllsIIH0FjkWgFtH6050=
-script: bundle _1.12.5_ exec rake test:unit
+script: bundle exec rake test:unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 before_install:
-- rvm @global do gem uninstall bundler --all --executables
-- gem uninstall bundler --all --executables
 - gem install bundler
 rvm:
 - 2.2.3

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,3 @@ group :development do
   gem "vagrant", git: "https://github.com/mitchellh/vagrant.git"
 end
 
-group :plugins do
-  gem "vagrant-windows-domain", path: "."
-end

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ config.vm.provision :windows_domain do |domain|
     # If not supplied the plugin will prompt the user during provisioning to provide one.
     domain.password = "iprobablyshouldntusethisfield"
 
+    # IP address of primary DNS server
+    #
+    # Specifies the IP address you want assigned as the primary DNS server for the primary nic.
+    # If not supplied, the nic's primary dns server will be assigned dynamically.
+    domain.primary_dns = "8.8.8.8"
+    
+    #IP address of the secondary DNS server
+    #
+    # Specifies the IP address you want assigned as the secondary DNS server for the primary nic
+    # If not supplied, the nic's secondary dns server will be assigned dynamically.
+	domain.secondary_dns = "8.8.4.4"
+
     # The set of Advanced options to pass when joining the Domain.
     #
     # See (https://technet.microsoft.com/en-us/library/hh849798.aspx) for detail, these are generally not required.

--- a/development/Vagrantfile
+++ b/development/Vagrantfile
@@ -13,7 +13,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "mfellows/windows2012r2"
   config.vm.guest = :windows
   config.vm.communicator = "winrm"
-  config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
+  #ALlows for vagrant to successfully connect to destination machine with winrm 
+  config.vm.network :forwarded_port, guest: 5985, host: 55985 #, id: "winrm", auto_correct: true
 
   config.vm.provider "virtualbox" do |v| 
     v.gui = true 

--- a/lib/vagrant-windows-domain/config.rb
+++ b/lib/vagrant-windows-domain/config.rb
@@ -40,6 +40,16 @@ module VagrantPlugins
       # The default value is the default OU for machine objects in the domain.
       attr_accessor :ou_path
 
+      # IP address of primary DNS server
+      #
+      # Specifies the IP address you want assigned as the primary DNS server for the primary nic
+      attr_accessor :primary_dns
+
+      #IP address of the secondary DNS server
+      #
+      # Specifies the IP address you want assigned as the secondary DNS server for the primary nic
+      attr_accessor :secondary_dns
+
       # Performs an unsecure join to the specified domain.
       #
       # When this option is used username/password are not required
@@ -56,6 +66,8 @@ module VagrantPlugins
         @password          = UNSET_VALUE
         @join_options      = {}
         @ou_path           = UNSET_VALUE
+        @primary_dns       = UNSET_VALUE
+        @secondary_dns     = UNSET_VALUE
         @unsecure          = UNSET_VALUE
         @rename            = UNSET_VALUE
         @logger            = Log4r::Logger.new("vagrant::vagrant_windows_domain")
@@ -75,6 +87,8 @@ module VagrantPlugins
         @password          = nil if @password == UNSET_VALUE || @password == ""
         @join_options      = [] if @join_options == UNSET_VALUE
         @ou_path           = nil if @ou_path == UNSET_VALUE
+        @primary_dns       = nil if @primary_dns == UNSET_VALUE
+        @secondary_dns     = nil if @secondary_dns == UNSET_VALUE
         @unsecure          = false if @unsecure == UNSET_VALUE
         @rename            = true if @rename == UNSET_VALUE
       end

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -215,6 +215,8 @@ module VagrantPlugins
             domain: @config.domain,
             computer_name: @config.computer_name,
             ou_path: @config.ou_path,
+            primary_dns: @config.primary_dns,
+            secondary_dns: @config.secondary_dns,
             add_to_domain: add_to_domain,
             unsecure: @config.unsecure,
             rename: @config.rename,
@@ -244,10 +246,6 @@ module VagrantPlugins
             params["-Unsecure"] = nil
           else
             params["-Credential $credentials"] = nil
-          end
-
-          if @config.computer_name != nil && @config.computer_name != @old_computer_name
-            params["-NewName"] = "'#{@config.computer_name}'"
           end
 
           if @config.ou_path

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -107,7 +107,7 @@ module VagrantPlugins
             restart_guest
 
             @logger.debug("Need to reboot to join the domain correctly - 2nd reboot")
-            restart_guest
+            #restart_guest
           end
         end
       end
@@ -157,7 +157,7 @@ module VagrantPlugins
             result = leave_domain
             if result
               @logger.debug("Need to reboot to leave the domain correctly")
-              restart_guest
+              #restart_guest
             end
           end
         else

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -31,11 +31,11 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	throw "$computerName already part of domain $domain"
 } else {
 	#If a value is provided for the Primary_DNS variable in the vagrantfile, powershell will attempt to determine if the string is a valid IP and will statically set the primary dns server of the vm's nic if it is.
-	<% if options[:Primary_DNS] != nil %>
-		$prim = '<%= options[:Primary_DNS] %>'
+	<% if options[:primary_dns] != nil %>
+		$prim = '<%= options[:primary_dns] %>'
 		If ($prim -match "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 		{
-			$wmi = Get-WmiObject -ComputerName $server -Namespace "root\CIMV2" -Class "Win32_NetworkAdapterconfiguration" -Filter 'IPENABLED=TRUE' -Impersonation Impersonate -ErrorAction Stop | Where-Object { $_.DefaultIPGateway }
+			$wmi = Get-WmiObject -ComputerName $env:COMPUTERNAME -Namespace "root\CIMV2" -Class "Win32_NetworkAdapterconfiguration" -Filter 'IPENABLED=TRUE' -Impersonation Impersonate -ErrorAction Stop | Where-Object { $_.DefaultIPGateway }
 			$currdns = $wmi.DNSServerSearchOrder
 			$wmi.SetDNSServerSearchOrder(@($prim, $currdns[1]))
 		}
@@ -46,11 +46,11 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	<% end %>
 
 	#If a value is provided for the Secondary_DNS variable in the vagrantfile, powershell will attempt to determine if the string is a valid IP and will statically set the secondary dns server of the vm's nic if it is.
-	<% if options[:Secondary_DNS] != nil %>
-		$sec = '<%= options[:Secondary_DNS] %>'
+	<% if options[:secondary_dns] != nil %>
+		$sec = '<%= options[:secondary_dns] %>'
 		If ($sec -match "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 		{
-			$wmi = Get-WmiObject -ComputerName $server -Namespace "root\CIMV2" -Class "Win32_NetworkAdapterconfiguration" -Filter 'IPENABLED=TRUE' -Impersonation Impersonate -ErrorAction Stop | Where-Object { $_.DefaultIPGateway }
+			$wmi = Get-WmiObject -ComputerName $env:COMPUTERNAME -Namespace "root\CIMV2" -Class "Win32_NetworkAdapterconfiguration" -Filter 'IPENABLED=TRUE' -Impersonation Impersonate -ErrorAction Stop | Where-Object { $_.DefaultIPGateway }
 			$currdns = $wmi.DNSServerSearchOrder
 			$wmi.SetDNSServerSearchOrder(@($currdns[0], $sec))
 		}
@@ -97,13 +97,12 @@ if (!(Test-JoinedToADomain)) {
 } else {
 	Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
 	Repair-OpenSSHPasswd
-
 	#removed the shutdown of the vm when disjoining it from the domain since, as the vm is about to be destroyed anyway, so there is no use for it.
 	# Fix vagrant-windows GH-129, if there's an existing scheduled
 	# reboot cancel it so shutdown succeeds
 	#&shutdown /a
 
 	# Force shutdown the machine now
-	#&shutdown /r /t 15 /c "Vagrant Halt" /f /d p:4:1
+	&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1
 }
 <% end %>

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -17,8 +17,11 @@ function Repair-OpenSSHPasswd(){
 		$passwd | Set-Content $passwdPath -Encoding Ascii
 	}
 }
-
+<% if options[:computer_name] != nil %>
 $computerName='<%= options[:computer_name] %>'
+<% else %>
+$computerName = $env:COMPUTERNAME
+<% end %>
 <% if options[:username] != nil && options[:unsecure] != true %>
 $domain='<%= options[:domain] %>'
 $username='<%= options[:username] %>'
@@ -63,7 +66,7 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	Add-Computer <%= options[:parameters] %> -Verbose -Force -PassThru
 
 	# Rename computer separately: Fixes GH issue #11
-	<% if options[:rename] === true %>
+	<% if options[:computer_name] != nil %>
 	$completed = $false
 	while ( -not $completed) {
 		try {
@@ -86,7 +89,7 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 
 	# Fix vagrant-windows GH-129, if there's an existing scheduled
 	# reboot cancel it so shutdown succeeds
-	&shutdown /a
+	#&shutdown /a
 
 	# Force shutdown the machine now
 	&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1	

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -29,6 +29,7 @@ $password='<%= options[:password] %>'
 $secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
 $credentials = New-Object System.Management.Automation.PSCredential ($username, $secpasswd)
 <% end %>
+
 <% if options[:add_to_domain] === true %>
 if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	throw "$computerName already part of domain $domain"
@@ -62,7 +63,7 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 			throw "Invalid IP address provided"
 		}
 	<% end %>
-
+	Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory private
 	Add-Computer <%= options[:parameters] %> -Verbose -Force -PassThru
 
 	# Rename computer separately: Fixes GH issue #11
@@ -92,7 +93,7 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	#&shutdown /a
 
 	# Force shutdown the machine now
-	&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1	
+	#&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1
 }
 <% else %>
 if (!(Test-JoinedToADomain)) {
@@ -106,6 +107,6 @@ if (!(Test-JoinedToADomain)) {
 	#&shutdown /a
 
 	# Force shutdown the machine now
-	&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1
+	#&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1
 }
 <% end %>

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -30,8 +30,38 @@ $credentials = New-Object System.Management.Automation.PSCredential ($username, 
 if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	throw "$computerName already part of domain $domain"
 } else {
+	#If a value is provided for the Primary_DNS variable in the vagrantfile, powershell will attempt to determine if the string is a valid IP and will statically set the primary dns server of the vm's nic if it is.
+	<% if options[:Primary_DNS] != nil %>
+		$prim = '<%= options[:Primary_DNS] %>'
+		If ($prim -match "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+		{
+			$wmi = Get-WmiObject -ComputerName $server -Namespace "root\CIMV2" -Class "Win32_NetworkAdapterconfiguration" -Filter 'IPENABLED=TRUE' -Impersonation Impersonate -ErrorAction Stop | Where-Object { $_.DefaultIPGateway }
+			$currdns = $wmi.DNSServerSearchOrder
+			$wmi.SetDNSServerSearchOrder(@($prim, $currdns[1]))
+		}
+		else
+		{
+			throw "Invalid IP address provided"
+		}
+	<% end %>
+
+	#If a value is provided for the Secondary_DNS variable in the vagrantfile, powershell will attempt to determine if the string is a valid IP and will statically set the secondary dns server of the vm's nic if it is.
+	<% if options[:Secondary_DNS] != nil %>
+		$sec = '<%= options[:Secondary_DNS] %>'
+		If ($sec -match "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+		{
+			$wmi = Get-WmiObject -ComputerName $server -Namespace "root\CIMV2" -Class "Win32_NetworkAdapterconfiguration" -Filter 'IPENABLED=TRUE' -Impersonation Impersonate -ErrorAction Stop | Where-Object { $_.DefaultIPGateway }
+			$currdns = $wmi.DNSServerSearchOrder
+			$wmi.SetDNSServerSearchOrder(@($currdns[0], $sec))
+		}
+		else
+		{
+			throw "Invalid IP address provided"
+		}
+	<% end %>
+
 	Add-Computer <%= options[:parameters] %> -Verbose -Force -PassThru
-	
+
 	# Rename computer separately: Fixes GH issue #11
 	<% if options[:rename] === true %>
 	$completed = $false
@@ -59,7 +89,7 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	&shutdown /a
 
 	# Force shutdown the machine now
-	&shutdown /s /t 15 /c "Vagrant Halt" /f /d p:4:1	
+	&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1	
 }
 <% else %>
 if (!(Test-JoinedToADomain)) {
@@ -68,11 +98,12 @@ if (!(Test-JoinedToADomain)) {
 	Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
 	Repair-OpenSSHPasswd
 
+	#removed the shutdown of the vm when disjoining it from the domain since, as the vm is about to be destroyed anyway, so there is no use for it.
 	# Fix vagrant-windows GH-129, if there's an existing scheduled
 	# reboot cancel it so shutdown succeeds
-	&shutdown /a
+	#&shutdown /a
 
 	# Force shutdown the machine now
-	&shutdown /r /t 15 /c "Vagrant Halt" /f /d p:4:1
+	#&shutdown /r /t 15 /c "Vagrant Halt" /f /d p:4:1
 }
 <% end %>

--- a/lib/vagrant-windows-domain/version.rb
+++ b/lib/vagrant-windows-domain/version.rb
@@ -1,5 +1,5 @@
 module Vagrant
   module WindowsDomain
-    VERSION = "1.3.2"
+    VERSION = "1.3.1"
   end
 end

--- a/lib/vagrant-windows-domain/version.rb
+++ b/lib/vagrant-windows-domain/version.rb
@@ -1,5 +1,5 @@
 module Vagrant
   module WindowsDomain
-    VERSION = "1.3.1"
+    VERSION = "1.3.2"
   end
 end

--- a/spec/provisioner/config_spec.rb
+++ b/spec/provisioner/config_spec.rb
@@ -37,8 +37,6 @@ describe VagrantPlugins::WindowsDomain::Config do
     its("username")          { should be_nil }
     its("password")          { should be_nil }
     its("join_options")      { should eq({})   }
-	its("primary_dns")		 { should be_nil }
-	its("secondary_dns")	 { should be_nil }
     its("ou_path")           { should be_nil }
     its("unsecure")          { should eq(false) }
 
@@ -47,8 +45,6 @@ describe VagrantPlugins::WindowsDomain::Config do
       subject.username = ""
       subject.password = ""
       subject.computer_name = ""
-      subject.primary_dns = ""
-      subject.secondary_dns = ""
       
       subject.finalize!
 
@@ -56,8 +52,6 @@ describe VagrantPlugins::WindowsDomain::Config do
       expect(subject.computer_name).to be_nil
       expect(subject.username).to be_nil
       expect(subject.password).to be_nil
-	  expect(subject.primary_dns).to be_nil
-	  expect(subject.secondary_dns).to be_nil
 	  
     end
   end

--- a/spec/provisioner/config_spec.rb
+++ b/spec/provisioner/config_spec.rb
@@ -37,6 +37,8 @@ describe VagrantPlugins::WindowsDomain::Config do
     its("username")          { should be_nil }
     its("password")          { should be_nil }
     its("join_options")      { should eq({})   }
+	its("primary_dns")		 { should be_nil }
+	its("secondary_dns")	 { should be_nil }
     its("ou_path")           { should be_nil }
     its("unsecure")          { should eq(false) }
 
@@ -45,6 +47,8 @@ describe VagrantPlugins::WindowsDomain::Config do
       subject.username = ""
       subject.password = ""
       subject.computer_name = ""
+      subject.primary_dns = ""
+      subject.secondary_dns = ""
       
       subject.finalize!
 
@@ -52,6 +56,9 @@ describe VagrantPlugins::WindowsDomain::Config do
       expect(subject.computer_name).to be_nil
       expect(subject.username).to be_nil
       expect(subject.password).to be_nil
+	  expect(subject.primary_dns).to be_nil
+	  expect(subject.secondary_dns).to be_nil
+	  
     end
   end
 

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -74,7 +74,7 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       allow(communicator).to receive(:upload)
       allow(ui).to receive(:info)
       expect(communicator).to receive(:test)
-      expect(vm).to receive(:boot_timeout).twice
+      expect(vm).to receive(:boot_timeout).once
       expect(communicator).to receive(:sudo).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1", {:elevated=>true, :error_check=>true, :error_key=>nil, :good_exit=>0, :shell=>:powershell})
       expect(communicator).to receive(:sudo).with("del c:/tmp/vagrant-windows-domain-runner.ps1")
       expect(machine).to receive(:action).with(:reload, {:provision_ignore_sentinel=>false, :lock=>false}).once
@@ -195,7 +195,6 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       expect(communicator).to receive(:sudo).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1", {:elevated=>true, :error_check=>true, :error_key=>nil, :good_exit=>0, :shell=>:powershell}).and_yield(:stdout, "deleted")
       expect(ui).to receive(:info).with("\"Running Windows Domain Provisioner\"")
       expect(ui).to receive(:info).with("deleted", {:color=>:green, :new_line=>false, :prefix=>false})
-      expect(ui).to receive(:say).with(:info, "Restarting computer for updates to take effect.")
 
       subject.destroy
     end
@@ -222,7 +221,6 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       expect(ui).to receive(:info).with(any_args).twice
       expect(ui).to receive(:ask).with("Please enter your domain password (output will be hidden): ", {:echo=>false}).and_return("myusername")
       expect(ui).to receive(:ask).with("Please enter your domain username: ")
-      expect(ui).to receive(:say).with(:info, "Restarting computer for updates to take effect.")
       subject.destroy
     end
 

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -77,8 +77,8 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       expect(vm).to receive(:boot_timeout).twice
       expect(communicator).to receive(:sudo).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1", {:elevated=>true, :error_check=>true, :error_key=>nil, :good_exit=>0, :shell=>:powershell})
       expect(communicator).to receive(:sudo).with("del c:/tmp/vagrant-windows-domain-runner.ps1")
-      expect(machine).to receive(:action).with(:reload, {:provision_ignore_sentinel=>false, :lock=>false}).twice
-      expect(communicator).to receive(:ready?).and_return(true).twice
+      expect(machine).to receive(:action).with(:reload, {:provision_ignore_sentinel=>false, :lock=>false}).once
+      expect(communicator).to receive(:ready?).and_return(true).once
       subject.restart_sleep_duration = 0
       subject.provision
       expect(subject.old_computer_name).to eq("myoldcomputername")
@@ -88,11 +88,11 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       allow(communicator).to receive(:upload)
       allow(ui).to receive(:info)
       expect(communicator).to receive(:test)
-      expect(vm).to receive(:boot_timeout).twice
+      expect(vm).to receive(:boot_timeout).once
       expect(communicator).to receive(:sudo).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1", {:elevated=>true, :error_check=>true, :error_key=>nil, :good_exit=>0, :shell=>:powershell})
       expect(communicator).to receive(:sudo).with("del c:/tmp/vagrant-windows-domain-runner.ps1")
-      expect(machine).to receive(:action). with(:reload, {:provision_ignore_sentinel=>false, :lock=>false}).twice
-      expect(communicator).to receive(:ready?).and_return(true).twice
+      expect(machine).to receive(:action). with(:reload, {:provision_ignore_sentinel=>false, :lock=>false}).once
+      expect(communicator).to receive(:ready?).and_return(true).once
       subject.restart_sleep_duration = 0
       subject.provision
     end
@@ -196,11 +196,6 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       expect(ui).to receive(:info).with("\"Running Windows Domain Provisioner\"")
       expect(ui).to receive(:info).with("deleted", {:color=>:green, :new_line=>false, :prefix=>false})
       expect(ui).to receive(:say).with(:info, "Restarting computer for updates to take effect.")
-      expect(machine).to receive(:action). with(:reload, {:provision_ignore_sentinel=>false, :lock=>false})
-      expect(ui).to_not receive(:say)
-      expect(ui).to_not receive(:ask)
-      expect(communicator).to receive(:ready?).and_return(true)
-      subject.restart_sleep_duration = 0      
 
       subject.destroy
     end
@@ -228,10 +223,6 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       expect(ui).to receive(:ask).with("Please enter your domain password (output will be hidden): ", {:echo=>false}).and_return("myusername")
       expect(ui).to receive(:ask).with("Please enter your domain username: ")
       expect(ui).to receive(:say).with(:info, "Restarting computer for updates to take effect.")
-      expect(machine).to receive(:action). with(:reload, {:provision_ignore_sentinel=>false, :lock=>false})
-      expect(communicator).to receive(:ready?).and_return(true)
-      subject.restart_sleep_duration = 0
-
       subject.destroy
     end
 

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -190,7 +190,6 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
     it "should leave domain when a `vagrant destroy` is issued" do
       allow(machine).to receive(:communicate).and_return(communicator)
       expect(communicator).to receive(:test).and_return(true)
-      expect(vm).to receive(:boot_timeout)
       expect(communicator).to receive(:upload)
       expect(communicator).to receive(:sudo).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1", {:elevated=>true, :error_check=>true, :error_key=>nil, :good_exit=>0, :shell=>:powershell}).and_yield(:stdout, "deleted")
       expect(ui).to receive(:info).with("\"Running Windows Domain Provisioner\"")
@@ -214,7 +213,6 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       allow(machine).to receive(:communicate).and_return(communicator)
       allow(machine).to receive(:env).and_return(env)
 
-      expect(vm).to receive(:boot_timeout)
       expect(communicator).to receive(:test).and_return(true)
       expect(communicator).to receive(:upload)
       expect(communicator).to receive(:sudo).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1", {:elevated=>true, :error_check=>true, :error_key=>nil, :good_exit=>0, :shell=>:powershell}).and_yield(:stdout, "deleted")

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -199,7 +199,7 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       expect(machine).to receive(:action). with(:reload, {:provision_ignore_sentinel=>false, :lock=>false})
       expect(ui).to_not receive(:say)
       expect(ui).to_not receive(:ask)
-      expect(communicator).to receive(:ready?).and_return(true)
+      expect(communicator).to_not receive(:ready?)
       subject.restart_sleep_duration = 0      
 
       subject.destroy

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -199,7 +199,7 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       expect(machine).to receive(:action). with(:reload, {:provision_ignore_sentinel=>false, :lock=>false})
       expect(ui).to_not receive(:say)
       expect(ui).to_not receive(:ask)
-      expect(communicator).to_not receive(:ready?)
+      expect(communicator).to receive(:ready?).and_return(true)
       subject.restart_sleep_duration = 0      
 
       subject.destroy

--- a/vagrant-windows-domain.gemspec
+++ b/vagrant-windows-domain.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "coveralls", "~> 0.8.10", '>= 0.8.10'
-  spec.add_development_dependency "rspec-core", '~> 3.4.2', '>= 3.4.2'
-  spec.add_development_dependency "rspec-expectations", '~> 3.4.0', '>= 3.4.0'
-  spec.add_development_dependency "rspec-mocks", '~> 3.4.1', '>= 3.4.1'
-  spec.add_development_dependency "rspec-its", "~> 1.2.0", '>= 1.2.0'
+  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "rspec-core"
+  spec.add_development_dependency "rspec-expectations"
+  spec.add_development_dependency "rspec-mocks"
+  spec.add_development_dependency "rspec-its"
 end

--- a/vagrant-windows-domain.gemspec
+++ b/vagrant-windows-domain.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "bundler", ">= 1.5.2", "<= 1.12.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls", "~> 0.8.10", '>= 0.8.10'
   spec.add_development_dependency "rspec-core", '~> 3.4.2', '>= 3.4.2'
   spec.add_development_dependency "rspec-expectations", '~> 3.4.0', '>= 3.4.0'

--- a/vagrant-windows-domain.gemspec
+++ b/vagrant-windows-domain.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-expectations", '~> 3.4.0', '>= 3.4.0'
   spec.add_development_dependency "rspec-mocks", '~> 3.4.1', '>= 3.4.1'
   spec.add_development_dependency "rspec-its", "~> 1.2.0", '>= 1.2.0'
-  spec.add_development_dependency "vagrant-spec", "~> 0.0.1", '>= 0.0.1'
 end

--- a/vagrant-windows-domain.gemspec
+++ b/vagrant-windows-domain.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-expectations", '~> 3.4.0', '>= 3.4.0'
   spec.add_development_dependency "rspec-mocks", '~> 3.4.1', '>= 3.4.1'
   spec.add_development_dependency "rspec-its", "~> 1.2.0", '>= 1.2.0'
+  spec.add_development_dependency "vagrant-spec", "~> 0.0.1", '>= 0.0.1'
 end


### PR DESCRIPTION
These changes fix several issues.  Two additional variables can be set in the vagrant file (primary_dns and secondary_dns) which will statically set the primary and secondary dns servers on the vm's nic, which, if configured correctly, can allow the vm to successfully communicate with the domain controller if the vm was unable to without setting the nic's DNS settings.  Also fixed an issue in regards to renaming the machine while domain-joining it.  The only thing I was unable to get perfect is that when destroying the vm, after the vm is removed from the domain, it has to restart prior to actually destroying the vm, but the plugin does work now.