### PR TITLE
Remove computer object from domain

### DIFF
--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -19,43 +19,6 @@ function Repair-OpenSSHPasswd(){
 }
 function New-ADSIPrincipalContext
 {
-<#
-.SYNOPSIS
-	Function to create an Active Directory PrincipalContext object
-
-.DESCRIPTION
-	Function to create an Active Directory PrincipalContext object
-
-.PARAMETER Credential
-	Specifies the alternative credentials to use.
-	It will use the current credential if not specified.
-
-.PARAMETER ContextType
-	Specifies which type of Context to use. Domain, Machine or ApplicationDirectory.
-
-.PARAMETER DomainName
-	Specifies the domain to query. Default is the current domain.
-	Should only be used with the Domain ContextType.
-
-.PARAMETER Container
-	Specifies the scope. Example: "OU=MyOU"
-
-.PARAMETER ContextOptions
-	Specifies the ContextOptions.
-	Negotiate
-	Sealing
-	SecureSocketLayer
-	ServerBind
-	Signing
-	SimpleBind
-
-.EXAMPLE
-	New-ADSIPrincipalContext -ContextType 'Domain'
-
-.EXAMPLE
-	New-ADSIPrincipalContext -ContextType 'Domain' -DomainName "Contoso.com" -Cred (Get-Credential)
-#>
-	
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	[OutputType('System.DirectoryServices.AccountManagement.PrincipalContext')]
 	PARAM
@@ -123,50 +86,6 @@ function New-ADSIPrincipalContext
 
 function Get-ADSIComputer
 {
-<#
-.SYNOPSIS
-	Function to retrieve a Computer in Active Directory
-
-.DESCRIPTION
-	Function to retrieve a Computer in Active Directory
-
-.PARAMETER Identity
-	Specifies the Identity of the computer
-		
-	You can provide one of the following:
-		DistinguishedName
-		Guid
-		Name
-		SamAccountName
-		Sid
-
-	System.DirectoryService.AccountManagement.IdentityType
-	https://msdn.microsoft.com/en-us/library/bb356425(v=vs.110).aspx
-
-.PARAMETER Credential
-	Specifies alternative credential
-	By default it will use the current user windows credentials.
-
-.PARAMETER DomainName
-	Specifies the alternative Domain.
-	By default it will use the current domain.
-
-.EXAMPLE
-	Get-ADSIComputer -Identity 'SERVER01'
-
-	This command will retrieve the computer account SERVER01
-
-.EXAMPLE
-	Get-ADSIComputer -Identity 'SERVER01' -Credential (Get-Credential)
-
-	This command will retrieve the computer account SERVER01 with the specified credential
-
-.EXAMPLE
-	$Comp = Get-ADSIComputer -Identity 'SERVER01'
-	$Comp.GetUnderlyingObject()| select-object *
-
-	Help you find all the extra properties
-#>
 	[CmdletBinding(DefaultParameterSetName="All")]
 	param ([Parameter(Mandatory=$true,ParameterSetName="Identity")]
 		[string]$Identity,
@@ -215,56 +134,6 @@ function Get-ADSIComputer
 
 function Remove-ADSIComputer
 {
-<#
-.SYNOPSIS
-	Function to Remove a Computer Account from a domain without needing to have the Remote server administration tools installed.  Also removes the 
-
-.DESCRIPTION
-	Function to Remove a Computer Account
-
-.PARAMETER Identity
-	Specifies the Identity of the Computer.
-
-	You can provide one of the following:
-		DistinguishedName
-		Guid
-		Name
-		SamAccountName
-		Sid
-
-.PARAMETER Credential
-	Specifies the alternative credential to use.
-	By default it will use the current user windows credentials.
-
-.PARAMETER DomainName
-	Specifies the alternative Domain.
-	By default it will use the current domain.
-
-.PARAMETER Recursive
-    Specifies that any child object should be deleted as well
-    Typically you would use this parameter if you get the error "The directory service can perform the requested operation only on a leaf object"
-    when you try to delete the object without the -recursive param
-
-.EXAMPLE
-	Remove-ADSIComputer -identity TESTSERVER01
-
-	This command will Remove the account TESTSERVER01
-
-.EXAMPLE
-	Remove-ADSIComputer -identity TESTSERVER01 -recursive
-
-	This command will Remove the account TESTSERVER01 and all the child leaf
-
-.EXAMPLE
-	Remove-ADSIComputer -identity TESTSERVER01 -whatif
-
-	This command will emulate removing the account TESTSERVER01
-
-.EXAMPLE
-	Remove-ADSIComputer -identity TESTSERVER01 -credential (Get-Credential)
-
-	This command will Remove the account TESTSERVER01 using the alternative credential specified
-#>
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	PARAM (
 		[parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ValueFromPipeline = $true)]

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -391,30 +391,15 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	<% end %>	
 	
 	Repair-OpenSSHPasswd
-
-	# Fix vagrant-windows GH-129, if there's an existing scheduled
-	# reboot cancel it so shutdown succeeds
-	#&shutdown /a
-
-	# Force shutdown the machine now
-	#&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1
 }
 <% else %>
 if (!(Test-JoinedToADomain)) {
 	Throw "$computerName not part of any domain"
 } else {
-	#Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
 	#When destroying the vagrant machine, the goal is not as much to have the virtual machine disjoin from the domain, but to remove the computer object associated with the
 	#machine so that future runs of vagrant up will succeed (especially when the vagrantfile explicitly defines a computer name.  That being the case, the remove-computer
 	#command has been replaced with a custom function which is able to remove the computer object associated with the vagrant machine in active directory.
 	Remove-ADSIComputer -Identity $env:COMPUTERNAME -DomainName $domain -Credential $credentials -Verbose
 	Repair-OpenSSHPasswd
-	#removed the shutdown of the vm when disjoining it from the domain since, as the vm is about to be destroyed anyway, so there is no use for it.
-	# Fix vagrant-windows GH-129, if there's an existing scheduled
-	# reboot cancel it so shutdown succeeds
-	#&shutdown /a
-
-	# Force shutdown the machine now
-	#&shutdown /r /t 0 /c "Vagrant Halt" /f /d p:4:1
 }
 <% end %>

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -17,6 +17,310 @@ function Repair-OpenSSHPasswd(){
 		$passwd | Set-Content $passwdPath -Encoding Ascii
 	}
 }
+function New-ADSIPrincipalContext
+{
+<#
+.SYNOPSIS
+	Function to create an Active Directory PrincipalContext object
+
+.DESCRIPTION
+	Function to create an Active Directory PrincipalContext object
+
+.PARAMETER Credential
+	Specifies the alternative credentials to use.
+	It will use the current credential if not specified.
+
+.PARAMETER ContextType
+	Specifies which type of Context to use. Domain, Machine or ApplicationDirectory.
+
+.PARAMETER DomainName
+	Specifies the domain to query. Default is the current domain.
+	Should only be used with the Domain ContextType.
+
+.PARAMETER Container
+	Specifies the scope. Example: "OU=MyOU"
+
+.PARAMETER ContextOptions
+	Specifies the ContextOptions.
+	Negotiate
+	Sealing
+	SecureSocketLayer
+	ServerBind
+	Signing
+	SimpleBind
+
+.EXAMPLE
+	New-ADSIPrincipalContext -ContextType 'Domain'
+
+.EXAMPLE
+	New-ADSIPrincipalContext -ContextType 'Domain' -DomainName "Contoso.com" -Cred (Get-Credential)
+#>
+	
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	[OutputType('System.DirectoryServices.AccountManagement.PrincipalContext')]
+	PARAM
+	(
+		[Alias("RunAs")]
+		[System.Management.Automation.PSCredential]
+		[System.Management.Automation.Credential()]
+		$Credential = [System.Management.Automation.PSCredential]::Empty,
+		
+		[Parameter(Mandatory = $true)]
+		[System.DirectoryServices.AccountManagement.ContextType]$ContextType,
+		
+		$DomainName = [System.DirectoryServices.ActiveDirectory.Domain]::Getcurrentdomain(),
+		
+		$Container,
+		
+		[System.DirectoryServices.AccountManagement.ContextOptions[]]$ContextOptions
+	)
+	
+	BEGIN
+	{
+		$ScriptName = (Get-Variable -name MyInvocation -Scope 0 -ValueOnly).MyCommand
+		Write-Verbose -Message "[$ScriptName] Add Type System.DirectoryServices.AccountManagement"
+		Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+	}
+	PROCESS
+	{
+		TRY
+		{
+			switch ($ContextType)
+			{
+				"Domain" { $ArgumentList = $ContextType, $DomainName }
+				"Machine" { $ArgumentList = $ContextType, $ComputerName }
+				"ApplicationDirectory" { $ArgumentList = $ContextType }
+			}
+			
+			IF ($PSBoundParameters['Container'])
+			{
+				$ArgumentList += $Container
+			}
+			
+			IF ($PSBoundParameters['ContextOptions'])
+			{
+				$ArgumentList += $($ContextOptions)
+			}
+			
+			IF ($PSBoundParameters['Credential'])
+			{
+				# Query the specified domain or current if not entered, with the specified credentials
+				$ArgumentList += $($Credential.UserName), $($Credential.GetNetworkCredential().password)
+			}
+			
+			IF ($PSCmdlet.ShouldProcess($DomainName, "Create Principal Context"))
+			{
+				# Query 
+				New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalContext -ArgumentList $ArgumentList
+			}
+		} #TRY
+		CATCH
+		{
+			$PSCmdlet.ThrowTerminatingError($_)
+		}
+	} #PROCESS
+}
+
+function Get-ADSIComputer
+{
+<#
+.SYNOPSIS
+	Function to retrieve a Computer in Active Directory
+
+.DESCRIPTION
+	Function to retrieve a Computer in Active Directory
+
+.PARAMETER Identity
+	Specifies the Identity of the computer
+		
+	You can provide one of the following:
+		DistinguishedName
+		Guid
+		Name
+		SamAccountName
+		Sid
+
+	System.DirectoryService.AccountManagement.IdentityType
+	https://msdn.microsoft.com/en-us/library/bb356425(v=vs.110).aspx
+
+.PARAMETER Credential
+	Specifies alternative credential
+	By default it will use the current user windows credentials.
+
+.PARAMETER DomainName
+	Specifies the alternative Domain.
+	By default it will use the current domain.
+
+.EXAMPLE
+	Get-ADSIComputer -Identity 'SERVER01'
+
+	This command will retrieve the computer account SERVER01
+
+.EXAMPLE
+	Get-ADSIComputer -Identity 'SERVER01' -Credential (Get-Credential)
+
+	This command will retrieve the computer account SERVER01 with the specified credential
+
+.EXAMPLE
+	$Comp = Get-ADSIComputer -Identity 'SERVER01'
+	$Comp.GetUnderlyingObject()| select-object *
+
+	Help you find all the extra properties
+#>
+	[CmdletBinding(DefaultParameterSetName="All")]
+	param ([Parameter(Mandatory=$true,ParameterSetName="Identity")]
+		[string]$Identity,
+		
+		[Alias("RunAs")]
+		[System.Management.Automation.PSCredential]
+		[System.Management.Automation.Credential()]
+		$Credential = [System.Management.Automation.PSCredential]::Empty,
+
+		[String]$DomainName
+	)
+	BEGIN
+	{
+        Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+		
+        # Create Context splatting
+        $ContextSplatting = @{ ContextType = "Domain" }
+		
+        IF ($PSBoundParameters['Credential']) { $ContextSplatting.Credential = $Credential }
+        IF ($PSBoundParameters['DomainName']) { $ContextSplatting.DomainName = $DomainName }
+		
+        $Context = New-ADSIPrincipalContext @ContextSplatting
+
+	}
+	PROCESS
+	{
+        TRY{
+            IF($Identity)
+            {
+                [System.DirectoryServices.AccountManagement.ComputerPrincipal]::FindByIdentity($Context, $Identity)
+            }
+            ELSE{
+                $ComputerPrincipal = New-object -TypeName System.DirectoryServices.AccountManagement.ComputerPrincipal -ArgumentList $Context
+			    $Searcher = new-object System.DirectoryServices.AccountManagement.PrincipalSearcher
+			    $Searcher.QueryFilter = $ComputerPrincipal
+
+                $Searcher.FindAll()
+            }
+        }
+        CATCH
+        {
+        	$pscmdlet.ThrowTerminatingError($_)
+        }
+	}
+}
+
+function Remove-ADSIComputer
+{
+<#
+.SYNOPSIS
+	Function to Remove a Computer Account from a domain without needing to have the Remote server administration tools installed.  Also removes the 
+
+.DESCRIPTION
+	Function to Remove a Computer Account
+
+.PARAMETER Identity
+	Specifies the Identity of the Computer.
+
+	You can provide one of the following:
+		DistinguishedName
+		Guid
+		Name
+		SamAccountName
+		Sid
+
+.PARAMETER Credential
+	Specifies the alternative credential to use.
+	By default it will use the current user windows credentials.
+
+.PARAMETER DomainName
+	Specifies the alternative Domain.
+	By default it will use the current domain.
+
+.PARAMETER Recursive
+    Specifies that any child object should be deleted as well
+    Typically you would use this parameter if you get the error "The directory service can perform the requested operation only on a leaf object"
+    when you try to delete the object without the -recursive param
+
+.EXAMPLE
+	Remove-ADSIComputer -identity TESTSERVER01
+
+	This command will Remove the account TESTSERVER01
+
+.EXAMPLE
+	Remove-ADSIComputer -identity TESTSERVER01 -recursive
+
+	This command will Remove the account TESTSERVER01 and all the child leaf
+
+.EXAMPLE
+	Remove-ADSIComputer -identity TESTSERVER01 -whatif
+
+	This command will emulate removing the account TESTSERVER01
+
+.EXAMPLE
+	Remove-ADSIComputer -identity TESTSERVER01 -credential (Get-Credential)
+
+	This command will Remove the account TESTSERVER01 using the alternative credential specified
+#>
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	PARAM (
+		[parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ValueFromPipeline = $true)]
+		$Identity,
+
+		[Alias("RunAs")]
+		[System.Management.Automation.PSCredential]
+		[System.Management.Automation.Credential()]
+		$Credential = [System.Management.Automation.PSCredential]::Empty,
+
+		[String]$DomainName,
+
+		[Switch]$Recursive
+	)
+	
+	BEGIN
+	{
+		Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+		
+		# Create Context splatting
+		$ContextSplatting = @{ }
+		IF ($PSBoundParameters['Credential']) { $ContextSplatting.Credential = $Credential }
+		IF ($PSBoundParameters['DomainName']) { $ContextSplatting.DomainName = $DomainName }
+
+	}
+	PROCESS
+	{
+		TRY
+		{
+			# Not Recursive
+			if (-not $PSBoundParameters['Recursive'])
+			{
+				if ($pscmdlet.ShouldProcess("$Identity", "Remove Account"))
+				{
+					$Account = Get-ADSIComputer -Identity $Identity @ContextSplatting
+					$Account.delete()
+				}
+			}
+			
+			# Recursive (if the computer is the parent of one leaf or more)
+			if ($PSBoundParameters['Recursive'])
+			{
+				if ($pscmdlet.ShouldProcess("$Identity", "Remove Account and any child objects"))
+				{
+					$Account = Get-ADSIComputer -Identity $Identity @ContextSplatting
+					$Account.GetUnderlyingObject().deletetree()
+				}
+			}
+			
+		}
+		CATCH
+		{
+			$pscmdlet.ThrowTerminatingError($_)
+		}
+	}
+}
 <% if options[:computer_name] != nil %>
 $computerName='<%= options[:computer_name] %>'
 <% else %>
@@ -99,7 +403,11 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 if (!(Test-JoinedToADomain)) {
 	Throw "$computerName not part of any domain"
 } else {
-	Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
+	#Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
+	#When destroying the vagrant machine, the goal is not as much to have the virtual machine disjoin from the domain, but to remove the computer object associated with the
+	#machine so that future runs of vagrant up will succeed (especially when the vagrantfile explicitly defines a computer name.  That being the case, the remove-computer
+	#command has been replaced with a custom function which is able to remove the computer object associated with the vagrant machine in active directory.
+	Remove-ADSIComputer -Identity $env:COMPUTERNAME -DomainName $domain -Credential $credentials -Verbose
 	Repair-OpenSSHPasswd
 	#removed the shutdown of the vm when disjoining it from the domain since, as the vm is about to be destroyed anyway, so there is no use for it.
 	# Fix vagrant-windows GH-129, if there's an existing scheduled

--- a/lib/vagrant-windows-domain/version.rb
+++ b/lib/vagrant-windows-domain/version.rb
@@ -1,5 +1,5 @@
 module Vagrant
   module WindowsDomain
-    VERSION = "1.3.2"
+    VERSION = "1.3.4"
   end
 end


### PR DESCRIPTION
Modified the plugin so that, when vagrant destroy is run, the computer object will be removed from the domain rather than the computer joining a workgroup, which prevents the user from having to manually delete the leftover computer object.